### PR TITLE
Fix chrome menu resize bug

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,11 +10,11 @@
     <ul id="site-nav">
     {% for node in site.pages %}
       {% if node.title %}
-      <a href="{{ node.url | prepend: site.baseurl }}">
-        <li class="page-link{% if node.url == page.url %} current{% endif %}">
+      <li class="page-link{% if node.url == page.url %} current{% endif %}">
+        <a href="{{ node.url | prepend: site.baseurl }}">
           <span>{{ node.title }}</span>
-        </li>
-      </a>
+        </a>
+      </li>
       {% endif %}
     {% endfor %}
     </ul>


### PR DESCRIPTION
Previously, the nav-header was layed out like this:

```
ul
  a
    li
  a
    li
  a
    li
```

The anchor tag (`<a>`) had a width and height of zero (refer to gif below). The bug was caused by the way the different browsers rendered zero-width float objects!

I've swapped the `<a>` and `<li>` so that the list is on the outside:

```
ul
  li
    a
  li
    a
  li
    a
```

List elements have non-zero width so the bug is fixed!


![peek 2017-08-07 15-46](https://user-images.githubusercontent.com/1589186/29029390-d4116e6a-7b87-11e7-94a8-a8646d80904b.gif)


Closes #4 <3